### PR TITLE
Add required option for SMILE python.

### DIFF
--- a/smile/flags.py
+++ b/smile/flags.py
@@ -101,9 +101,10 @@ class _FlagValues(object):  # pylint: disable=too-few-public-methods
         self.__dict__['__flags'][name] = value
 
 
-def _define_helper(flag_name, default_value, docstring, flagtype):
+def _define_helper(flag_name, default_value, docstring, flagtype, required):
     """Registers 'flag_name' with 'default_value' and 'docstring'."""
-    get_context_parser().add_argument('--' + flag_name,
+    option_name = flag_name if required else "--%s" % flag_name
+    get_context_parser().add_argument(option_name,
                                       default=default_value,
                                       help=docstring,
                                       type=flagtype)
@@ -113,24 +114,24 @@ def _define_helper(flag_name, default_value, docstring, flagtype):
 FLAGS = _FlagValues()
 
 
-def DEFINE_string(flag_name, default_value, docstring): # pylint: disable=invalid-name
+def DEFINE_string(flag_name, default_value, docstring, required=False): # pylint: disable=invalid-name
     """Defines a flag of type 'string'.
     Args:
         flag_name: The name of the flag as a string.
         default_value: The default value the flag should take as a string.
         docstring: A helpful message explaining the use of the flag.
     """
-    _define_helper(flag_name, default_value, docstring, str)
+    _define_helper(flag_name, default_value, docstring, str, required)
 
 
-def DEFINE_integer(flag_name, default_value, docstring): # pylint: disable=invalid-name
+def DEFINE_integer(flag_name, default_value, docstring, required=False): # pylint: disable=invalid-name
     """Defines a flag of type 'int'.
     Args:
         flag_name: The name of the flag as a string.
         default_value: The default value the flag should take as an int.
         docstring: A helpful message explaining the use of the flag.
     """
-    _define_helper(flag_name, default_value, docstring, int)
+    _define_helper(flag_name, default_value, docstring, int, required)
 
 
 def DEFINE_boolean(flag_name, default_value, docstring): # pylint: disable=invalid-name
@@ -164,11 +165,11 @@ def DEFINE_boolean(flag_name, default_value, docstring): # pylint: disable=inval
 DEFINE_bool = DEFINE_boolean  # pylint: disable=invalid-name
 
 
-def DEFINE_float(flag_name, default_value, docstring): # pylint: disable=invalid-name
+def DEFINE_float(flag_name, default_value, docstring, required=False): # pylint: disable=invalid-name
     """Defines a flag of type 'float'.
     Args:
         flag_name: The name of the flag as a string.
         default_value: The default value the flag should take as a float.
         docstring: A helpful message explaining the use of the flag.
     """
-    _define_helper(flag_name, default_value, docstring, float)
+    _define_helper(flag_name, default_value, docstring, float, required)

--- a/tests/python/test_flags.py
+++ b/tests/python/test_flags.py
@@ -11,6 +11,7 @@ flags.DEFINE_string("string_foo", "default_val", "HelpString")
 flags.DEFINE_integer("int_foo", 42, "HelpString")
 flags.DEFINE_float("float_foo", 42.0, "HelpString")
 
+
 flags.DEFINE_boolean("bool_foo", True, "HelpString")
 flags.DEFINE_boolean("bool_negation", True, "HelpString")
 flags.DEFINE_boolean("bool-dash-negation", True, "HelpString")
@@ -32,6 +33,11 @@ with flags.Subcommand("move", dest="action"):
     with flags.Subcommand("wa", dest="object"):
         flags.DEFINE_string("move_wa_string", "default_wa", "help")
         flags.DEFINE_bool("move_wa_bool", False, "HelpString")
+
+with flags.Subcommand("require", dest="action"):
+    flags.DEFINE_string("string_foo_required", "default_val", "HelpString", required=True)
+    flags.DEFINE_integer("int_foo_required", 42, "HelpString", required=True)
+    flags.DEFINE_float("float_foo_required", 42.0, "HelpString", required=True)
 
 FLAGS = flags.FLAGS
 
@@ -128,3 +134,11 @@ class FlagsTest(unittest.TestCase):
             self.assertEquals("move", FLAGS.action)
             self.assertEquals("default", FLAGS.move_string)
             self.assertTrue(FLAGS.move_bool)
+
+    def test_required(self):
+        """Test required key flags."""
+        FLAGS._parse_flags(["require", "str_foo", "1", "0.5"]) # pylint: disable=protected-access
+        self.assertEquals("require", FLAGS.action)
+        self.assertEquals("str_foo", FLAGS.string_foo_required)
+        self.assertEquals(1, FLAGS.int_foo_required)
+        self.assertEquals(0.5, FLAGS.float_foo_required)


### PR DESCRIPTION
At this moment, we can define some **required** flag like:
```python
# file-name: test_required.py
import smile as sm
sm.app.flags.DEFINE_float("float_foo_required", 42.0, "HelpString", required=True)
```

Then if the user does not supply the `float_foo_required` with 
```
python test_required.py 12.0
```
It will produce some error message.