### PR TITLE
abseil-py (absl) integration.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name="smile",
     version=__version__,
     description=
-    "smile-python contains a library of powerful tools for python programming.",
+    "smile-python is an modern absl-like python library for SMILE lab.",
     install_requires=["absl-py"],
     author="Zheng Xu",
     author_email="zheng.xu@mavs.uta.edu",

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ __version__ = "0.0.4"
 setup(
     name="smile",
     version=__version__,
-    description="SMILE is a gflags-like but more powerful command line argument parser.",
-    install_requires=[],
+    description=
+    "smile-python contains a library of powerful tools for python programming.",
+    install_requires=["absl-py"],
     author="Zheng Xu",
     author_email="zheng.xu@mavs.uta.edu",
     zip_safe=False,
     packages=["smile"],
-    url="https://github.com/uta-smile/smile-python/"
-)
+    url="https://github.com/uta-smile/smile-python/")

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name="smile",
     version=__version__,
     description=
-    "smile-python is an modern absl-like python library for SMILE lab.",
+    "smile-python is a modern absl-like python library for SMILE lab.",
     install_requires=["absl-py"],
     author="Zheng Xu",
     author_email="zheng.xu@mavs.uta.edu",

--- a/smile/__init__.py
+++ b/smile/__init__.py
@@ -3,3 +3,6 @@
 # Expose some internal module for outer use.
 from smile import app
 from smile import flags
+
+# Reuse the abseil-py logging module.
+from absl import logging as logging

--- a/smile/__init__.py
+++ b/smile/__init__.py
@@ -5,4 +5,4 @@ from smile import app
 from smile import flags
 
 # Reuse the abseil-py logging module.
-from absl import logging as logging
+from absl import logging

--- a/smile/app.py
+++ b/smile/app.py
@@ -5,12 +5,14 @@ from __future__ import print_function
 
 import sys
 
+from absl import flags as absl_flags
 from smile import flags
 
 
 def run(main=None, argv=None):
     """Runs the program with an optional 'main' function and 'argv' list."""
     flags_obj = flags.FLAGS
+    absl_flags_obj = absl_flags.FLAGS
 
     # Extract the args from the optional `argv` list.
     args = argv[1:] if argv else None
@@ -20,6 +22,11 @@ def run(main=None, argv=None):
     # pylint: disable=protected-access
     flags_passthrough = flags_obj._parse_flags(args=args)
     # pylint: enable=protected-access
+
+    # Immediately after flags are parsed, bump verbosity to INFO if the flag has
+    # not been set.
+    if absl_flags_obj["verbosity"].using_default_value:
+        absl_flags_obj.verbosity = 0
 
     main = main or sys.modules['__main__'].main
 

--- a/smile/flags.py
+++ b/smile/flags.py
@@ -4,9 +4,12 @@ from __future__ import division
 from __future__ import print_function
 
 import argparse as _argparse
+import sys
+
+from absl import flags as absl_flags
 
 
-class NamedParser(object): # pylint: disable=too-few-public-methods
+class NamedParser(object):  # pylint: disable=too-few-public-methods
     """Parser object with name."""
 
     def __init__(self, name, parser):
@@ -20,7 +23,8 @@ class NamedParser(object): # pylint: disable=too-few-public-methods
         if not self._subparsers:
             self._subparsers = self.parser.add_subparsers(dest=dest)
         elif self._subparsers.dest != dest:
-            raise KeyError("Subparsers name mismatch. You can only create one subcommand.")
+            raise KeyError(
+                "Subparsers name mismatch. You can only create one subcommand.")
         return self._subparsers
 
     def get_subparser(self, name, dest="subcommand", **kwargs):
@@ -32,10 +36,11 @@ class NamedParser(object): # pylint: disable=too-few-public-methods
             self.children[name] = NamedParser(name, parser)
         return self.children[name]
 
+
 _GLOBAL_PARSER = NamedParser("root", _argparse.ArgumentParser())
 
 
-class Subcommand(object): # pylint: disable=too-few-public-methods
+class Subcommand(object):  # pylint: disable=too-few-public-methods
     """Subcommand Context. Provide support for subcommand."""
 
     DEFAULT_CONTEXT = None
@@ -67,6 +72,7 @@ def get_context_parser():
     """Get context parser."""
     return Subcommand.CURRENT_PARSER.parser
 
+
 def get_root_parser():
     """Get root parser."""
     return _GLOBAL_PARSER.parser
@@ -80,19 +86,25 @@ class _FlagValues(object):  # pylint: disable=too-few-public-methods
         self.__dict__['__parsed'] = False
 
     def _parse_flags(self, args=None):
+        # Use argparse to parse first.
         result, unparsed = get_root_parser().parse_known_args(args=args)
         for flag_name, val in vars(result).items():
             self.__dict__['__flags'][flag_name] = val
         self.__dict__['__parsed'] = True
+        # Parse the rest flags with absl.
+        unparsed = absl_flags.FLAGS(sys.argv[:1] + unparsed)
         return unparsed
 
     def __getattr__(self, name):
         """Retrieves the 'value' attribute of the flag --name."""
         if not self.__dict__['__parsed']:
             self._parse_flags()
-        if name not in self.__dict__['__flags']:
+        value = self.__dict__['__flags'].get(name, None)
+        if value is None:
+            value = getattr(absl_flags.FLAGS, name, None)
+        if value is None:
             raise AttributeError(name)
-        return self.__dict__['__flags'][name]
+        return value
 
     def __setattr__(self, name, value):
         """Sets the 'value' attribute of the flag --name."""
@@ -104,17 +116,15 @@ class _FlagValues(object):  # pylint: disable=too-few-public-methods
 def _define_helper(flag_name, default_value, docstring, flagtype, required):
     """Registers 'flag_name' with 'default_value' and 'docstring'."""
     option_name = flag_name if required else "--%s" % flag_name
-    get_context_parser().add_argument(option_name,
-                                      default=default_value,
-                                      help=docstring,
-                                      type=flagtype)
+    get_context_parser().add_argument(
+        option_name, default=default_value, help=docstring, type=flagtype)
 
 
 # Provides the global object that can be used to access flags.
 FLAGS = _FlagValues()
 
 
-def DEFINE_string(flag_name, default_value, docstring, required=False): # pylint: disable=invalid-name
+def DEFINE_string(flag_name, default_value, docstring, required=False):  # pylint: disable=invalid-name
     """Defines a flag of type 'string'.
     Args:
         flag_name: The name of the flag as a string.
@@ -124,7 +134,7 @@ def DEFINE_string(flag_name, default_value, docstring, required=False): # pylint
     _define_helper(flag_name, default_value, docstring, str, required)
 
 
-def DEFINE_integer(flag_name, default_value, docstring, required=False): # pylint: disable=invalid-name
+def DEFINE_integer(flag_name, default_value, docstring, required=False):  # pylint: disable=invalid-name
     """Defines a flag of type 'int'.
     Args:
         flag_name: The name of the flag as a string.
@@ -134,30 +144,33 @@ def DEFINE_integer(flag_name, default_value, docstring, required=False): # pylin
     _define_helper(flag_name, default_value, docstring, int, required)
 
 
-def DEFINE_boolean(flag_name, default_value, docstring): # pylint: disable=invalid-name
+def DEFINE_boolean(flag_name, default_value, docstring):  # pylint: disable=invalid-name
     """Defines a flag of type 'boolean'.
     Args:
         flag_name: The name of the flag as a string.
         default_value: The default value the flag should take as a boolean.
         docstring: A helpful message explaining the use of the flag.
     """
+
     # Register a custom function for 'bool' so --flag=True works.
     def str2bool(bool_str):
         """Return a boolean value from a give string."""
         return bool_str.lower() in ('true', 't', '1')
 
-    get_context_parser().add_argument('--' + flag_name,
-                                      nargs='?',
-                                      const=True,
-                                      help=docstring,
-                                      default=default_value,
-                                      type=str2bool)
+    get_context_parser().add_argument(
+        '--' + flag_name,
+        nargs='?',
+        const=True,
+        help=docstring,
+        default=default_value,
+        type=str2bool)
 
     # Add negated version, stay consistent with argparse with regard to
     # dashes in flag names.
-    get_context_parser().add_argument('--no' + flag_name,
-                                      action='store_false',
-                                      dest=flag_name.replace('-', '_'))
+    get_context_parser().add_argument(
+        '--no' + flag_name,
+        action='store_false',
+        dest=flag_name.replace('-', '_'))
 
 
 # The internal google library defines the following alias, so we match
@@ -165,7 +178,7 @@ def DEFINE_boolean(flag_name, default_value, docstring): # pylint: disable=inval
 DEFINE_bool = DEFINE_boolean  # pylint: disable=invalid-name
 
 
-def DEFINE_float(flag_name, default_value, docstring, required=False): # pylint: disable=invalid-name
+def DEFINE_float(flag_name, default_value, docstring, required=False):  # pylint: disable=invalid-name
     """Defines a flag of type 'float'.
     Args:
         flag_name: The name of the flag as a string.

--- a/smile/flags.py
+++ b/smile/flags.py
@@ -110,7 +110,12 @@ class _FlagValues(object):  # pylint: disable=too-few-public-methods
         """Sets the 'value' attribute of the flag --name."""
         if not self.__dict__['__parsed']:
             self._parse_flags()
-        self.__dict__['__flags'][name] = value
+        if name not in self.__dict__['__flags']:
+            absl_value = getattr(absl_flags.FLAGS, name, None)
+            if absl_value is not None:
+                setattr(absl_flags.FLAGS, name, value)
+            else:
+                self.__dict__['__flags'][name] = value
 
 
 def _define_helper(flag_name, default_value, docstring, flagtype, required):

--- a/smile/flags.py
+++ b/smile/flags.py
@@ -24,7 +24,7 @@ class NamedParser(object):  # pylint: disable=too-few-public-methods
             self._subparsers = self.parser.add_subparsers(dest=dest)
         elif self._subparsers.dest != dest:
             raise KeyError(
-                "Subparsers name mismatch. You can only create one subcommand.")
+                "Subparser names mismatch. You can only create one subcommand.")
         return self._subparsers
 
     def get_subparser(self, name, dest="subcommand", **kwargs):

--- a/tests/python/test_flags.py
+++ b/tests/python/test_flags.py
@@ -146,3 +146,10 @@ class FlagsTest(unittest.TestCase):
         self.assertEqual("str_foo", FLAGS.string_foo_required)
         self.assertEqual(1, FLAGS.int_foo_required)
         self.assertEqual(0.5, FLAGS.float_foo_required)
+
+    def test_absl_logging_flags(self):
+        """Test absl logging flags."""
+        self.assertFalse(FLAGS.logtostderr)
+        self.assertFalse(FLAGS.alsologtostderr)
+        FLAGS._parse_flags(["move", "wa", "--alsologtostderr"])  # pylint: disable=protected-access
+        self.assertTrue(FLAGS.alsologtostderr)

--- a/tests/python/test_logging.py
+++ b/tests/python/test_logging.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+
+from smile import logging
+
+
+class FlagsTest(unittest.TestCase):
+    """Unit tests for logging library."""
+
+    def test_integration_log(self):
+        """This test simply should not return any error."""
+        logging.info("This is a info test message.")
+        logging.warning("This is a warning test message.")
+        logging.error("This is an error message.")
+        logging.log(logging.INFO, "This is just another info test message.")
+        logging.debug("This is a debug test message.")
+        # TODO(XericZephyr@): Figure out how to test fatal logging.

--- a/tests/python/test_logging.py
+++ b/tests/python/test_logging.py
@@ -1,3 +1,4 @@
+"""An integration test module for logging module."""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -10,7 +11,7 @@ from smile import logging
 class FlagsTest(unittest.TestCase):
     """Unit tests for logging library."""
 
-    def test_integration_log(self):
+    def test_integration_log(self):  # pylint: disable=no-self-use
         """This test simply should not return any error."""
         logging.info("This is a info test message.")
         logging.warning("This is a warning test message.")

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -4,7 +4,7 @@
 set -e
 
 # perform lint test for all files
-pylint -r n --output-format=colorized smile tests/python/ setup.py
+pylint -r n --disable=fixme --output-format=colorized smile tests/python/ setup.py
 
 # perform nosetests
 PYTHONPATH=`pwd` nosetests

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,10 +1,17 @@
 # !/bin/bash
 
 # Return error if any script returns a non-zero exit code.
-set -e
+set -eu
 
 # perform lint test for all files
-pylint -r n --disable=fixme --output-format=colorized smile tests/python/ setup.py
+pylint -r n --disable=fixme --output-format=colorized smile tests/python/ \
+setup.py tests/smoke_tests/smoke_test.py
 
 # perform nosetests
 PYTHONPATH=`pwd` nosetests
+
+# run smoke tests.
+bash tests/smoke_tests/smoke_test.sh
+
+# Indicate all tests have passed.
+echo "All tests passed."

--- a/tests/smoke_tests/smoke_test.py
+++ b/tests/smoke_tests/smoke_test.py
@@ -1,0 +1,24 @@
+"""Test helper for smoke_test.sh."""
+
+# Similar to https://github.com/abseil/abseil-py/blob/master/smoke_tests/smoke_test.py
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import smile as sm
+from smile import flags
+from smile import logging
+
+flags.DEFINE_string("param", "default_value", "some help infomation")
+
+FLAGS = flags.FLAGS
+
+
+def main(_):
+    """Print out the FLAGS in the main function."""
+    logging.info("param = %s", FLAGS.param)
+
+
+if __name__ == "__main__":
+    sm.app.run()

--- a/tests/smoke_tests/smoke_test.sh
+++ b/tests/smoke_tests/smoke_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+echo "Starting smoke tests..."
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+SMOKE_TEST_PY="${DIR}/smoke_test.py"
+
+RET=`python $SMOKE_TEST_PY 2>&1`
+echo $RET | grep 'param = default_value'
+
+echo "Smoke tests passed."


### PR DESCRIPTION
This PR solves #17 .

Now the smile package can live together with Google's absl package.
Smile package is even better than absl given the use of modern `argparse` package. This brings the support of subcommand, positional flags, flag alias, and so on. 

General usage suggestion should be changed to 
```
Whenever you would like to use absl in python, you should use smile package instead.
``` 

