### PR TITLE
Replace logging.warn() with logging.warning() to avoid deprecated warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ def main(_):
     """Print out the FLAGS in the main function."""
     logging.info("param = %s", FLAGS.param)
     if FLAGS.action == "echo":
-        logging.warn(FLAGS.echo_text)
+        logging.warning(FLAGS.echo_text)
     elif FLAGS.action == "echo_bool":
         logging.info("Just do it? %s", "Yes!" if FLAGS.just_do_it else "No :(")
 

--- a/tests/smoke_tests/smoke_test.py
+++ b/tests/smoke_tests/smoke_test.py
@@ -25,7 +25,7 @@ def main(_):
     """Print out the FLAGS in the main function."""
     logging.info("param = %s", FLAGS.param)
     if FLAGS.action == "echo":
-        logging.warn(FLAGS.echo_text)
+        logging.warning(FLAGS.echo_text)
     elif FLAGS.action == "echo_bool":
         logging.info("Just do it? %s", "Yes!" if FLAGS.just_do_it else "No :(")
 


### PR DESCRIPTION
My comment for #21 seems missing so this PR is to replace the logging.warn() with logging.warning() to avoid deprecated warnings.